### PR TITLE
Fix typo in Health Connect Endpoint example

### DIFF
--- a/input/fsh/Examples/06.1 hc-endpoint-ex-1.fsh
+++ b/input/fsh/Examples/06.1 hc-endpoint-ex-1.fsh
@@ -1,8 +1,8 @@
 Instance: example-hc-endpoint-smd
 InstanceOf: HCEndpoint
 Usage: #example
-Title: "HC Endpoint - SMD Target Example"
-Description: "Example of a Health Connect endpoint with SMD target identifier for secure messaging."
+Title: "Health Connect Endpoint - SMD Target Example"
+Description: "An example of a Health Connect endpoint with SMD target identifier for secure messaging."
 
 * meta.source = "http://ns.electronichealth.net.au/id/source/pca"
 


### PR DESCRIPTION
All of the other examples started with Health Connect but this one started with HC, so this just brings them into line. There are some other inconsistencies in the examples interms of the resource name being before or after the hyphen.

Built version:
![Uploading Screenshot 2025-11-20 at 2.48.28 pm.png…]()
