### PR TITLE
Introduce development container / Docker environment 

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,42 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
+
+# https://github.com/FHIR/sushi/releases/tag/v3.17.0
+ARG SUSHI_VERSION="v3.17.0"
+# https://github.com/HL7/fhir-ig-publisher/releases/tag/2.0.30
+ARG FHIR_IG_PUBLISHER_VERSION="2.0.30"
+ARG FHIR_IG_PUBLISHER_SHA256SUM="2501140e3dbb9e62c51d44327fb3dbfc2d9d32b197f3d681b9b728790013bec0"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+WORKDIR /opt
+
+RUN apt update \
+  && apt install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    git \
+    gnupg \
+    build-essential \
+    zlib1g-dev \
+    libffi-dev \
+    libyaml-dev \
+    ruby-full \
+    openjdk-17-jre-headless \
+  && apt clean \
+  && rm -rf /var/lib/apt/lists/*
+
+# Setup Node.js
+RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
+  && apt install -y --no-install-recommends nodejs
+
+# Setup Ruby
+RUN gem install --no-document jekyll bundler
+
+# Install SUSHI
+RUN npm install -g fsh-sushi@${SUSHI_VERSION}
+
+# Download FHIR IG Publisher 
+RUN mkdir -p input-cache \
+  && curl -L "https://github.com/HL7/fhir-ig-publisher/releases/download/${FHIR_IG_PUBLISHER_VERSION}/publisher.jar" -o "input-cache/publisher.jar" \
+  && echo "${FHIR_IG_PUBLISHER_SHA256SUM}  input-cache/publisher.jar" | sha256sum -c - \
+  && chmod 644 input-cache/publisher.jar

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+  "name": "Health Connect IG",
+  "build": {
+    "dockerfile": "./Dockerfile",
+    "context": "."
+  },
+  "remoteUser": "vscode",
+  "forwardPorts": [
+    3000
+  ],
+  "portsAttributes": {
+    "3000": {
+      "label": "IG preview (Jekyll)"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -15,13 +15,40 @@ https://build.fhir.org/ig/AuDigitalHealth/HealthConnect/index.html
 
 ## How to Build
 
-### Pre-requisites
-[SUSHI](https://fshschool.org/docs/sushi/installation/) - Ensure you have Node JS installed, and then install SUSHI via `npm install -g fsh-sushi`
+Welcome! There are two easy ways to build this IG. If you’re on Windows (or just want fewer local installs), the dev container is the smoothest path.
 
-[Jekyll](https://jekyllrb.com/docs/installation/) - Jekyll is a Ruby Gem and instructions are available for various operating systems.
+### Option A: Dev Container (recommended)
+This keeps your machine clean and works the same on Windows, macOS, and Linux.
+- Install [Docker Desktop](https://docs.docker.com/desktop/setup/install/windows-install/).
+- Install VS Code + the Dev Containers extension.
+- Open this repo in VS Code and choose “Reopen in Container”.
 
-### Building
-Run either the `_genonce.bat` or `_genonce.sh` script.
+The container includes everything you need: Java, Node.js + SUSHI, Ruby + Jekyll, and curl.
+
+### Option B: Local setup
+Prefer to run natively? Install the same dependencies:
+- Java (OpenJDK 17+)
+- Node.js + SUSHI (`npm install -g fsh-sushi`)
+- Ruby + Jekyll (`gem install jekyll bundler`)
+- curl
+
+### Build the IG
+Run the script for your OS:
+- Windows: `_genonce.bat`
+- macOS/Linux: `./_genonce.sh`
+
+If `publisher.jar` is missing, run `_updatePublisher.bat` or `_updatePublisher.sh` first.
+
+### Preview/Serve (Jekyll)
+To preview the site locally (with live rebuilds):
+1) Build the IG (`_genonce.bat` or `./_genonce.sh`) — this runs `publisher.jar`.
+2) Start Jekyll to serve the generated pages.
+
+Example (macOS/Linux or Dev Container):
+- Build: `./_genonce.sh`
+- Serve: `jekyll serve -s temp/pages -d output -H 0.0.0.0 -P 3000`
+
+The static site is written to `output/`.
 
  
 ## Contributing
@@ -29,4 +56,3 @@ Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute.
  
 ## License
 This project is licensed under Creative Commons license 4.0 - see the [LICENSE](LICENSE) file for details.
-


### PR DESCRIPTION
Hello ADHA 👋🏼 

I was playing around with this repo tonight and felt like this setup might help others down the road get started a little bit quicker/easier and without setting up as much bloat.

**What I did** 

  - Added a devcontainer workflow to make setup easier and more consistent across platforms (especially Windows).
  - Set the devcontainer to download `publisher.jar` by default so builds work out of the box.
  - Kept caching out of scope for now — I didn’t introduce cache mounts without checking in first.

 **Why**

  - Reduce _(hopefully)_ onboarding friction and make the build reproducible for new contributors.
  - Ensure the IG Publisher is always available without manual steps.